### PR TITLE
LS vectors and tests

### DIFF
--- a/src/bothLigands.jl
+++ b/src/bothLigands.jl
@@ -104,8 +104,11 @@ end
 totalLS = vcat(ones(9), 2 * ones(5), ones(9) * internalFrac, 2 * ones(5) * internalFrac, zeros(2))
 surfaceLS = vcat(ones(14), zeros(16))
 pYcLS = vcat(zeros(9), ones(5))
+pYLS = vcat(pYcLS, pYcLS, zeros(2))
 GascLS = vcat(0, ones(2), zeros(2), 2, 1, 0, 1, 2, 1, zeros(2), 1)
 PROScLS = vcat(zeros(3), ones(2), 0, 1, 2, 1, zeros(2), 1, 2, 1)
+GasLS = vcat(GascLS, GascLS, 1, 0)
+PROSLS = vcat(PROScLS, PROScLS, 0, 1)
 
 
 function TAMreact(dR, R, tr::Lsrates, t)

--- a/test/testLS.jl
+++ b/test/testLS.jl
@@ -66,7 +66,7 @@
 
         data = TAMode.runTAM(tps, rr, (0.0, 10.0))
 
-        @test aboutZero.(data * TAMode.GasLS)
+        @test all(aboutZero.(data * TAMode.GasLS))
     end
     
     @testset "LS: Test that if no Protein S is present, we don’t see any." begin
@@ -75,7 +75,7 @@
 
         data = TAMode.runTAM(tps, rr, (10.0, 0.0))
 
-        @test aboutZero.(data * TAMode.PROSLS)
+        @test all(aboutZero.(data * TAMode.PROSLS))
     end
     
     @testset "LS: Test that if no ligand is present, we don’t see any pY." begin
@@ -84,6 +84,6 @@
 
         data = TAMode.runTAM(tps, rr, (0.0, 0.0))
 
-        @test aboutZero.(data * TAMode.pYLS)
+        @test all(aboutZero.(data * TAMode.pYLS))
     end
 end

--- a/test/testLS.jl
+++ b/test/testLS.jl
@@ -62,28 +62,28 @@
     
     @testset "LS: Test that if no Gas6 is present, we don’t see any." begin
         rr = TAMode.Lsparam(fill(0.2, 9))
-        rr.curL = (0, 0)
+        rr.curL = (0.0, 0.0)
 
-        data = TAMode.runTAM(tps, rr, (0, 10))
+        data = TAMode.runTAM(tps, rr, (0.0, 10.0))
 
-        @test all(data * TAMode.GasLS .≈ 0)
+        @test aboutZero.(data * TAMode.GasLS)
     end
     
     @testset "LS: Test that if no Protein S is present, we don’t see any." begin
         rr = TAMode.Lsparam(fill(0.2, 9))
-        rr.curL = (0, 0)
+        rr.curL = (0.0, 0.0)
 
-        data = TAMode.runTAM(tps, rr, (10, 0))
+        data = TAMode.runTAM(tps, rr, (10.0, 0.0))
 
-        @test all(data * TAMode.PROSLS .≈ 0)
+        @test aboutZero.(data * TAMode.PROSLS)
     end
     
     @testset "LS: Test that if no ligand is present, we don’t see any pY." begin
         rr = TAMode.Lsparam(fill(0.2, 9))
-        rr.curL = (0, 0)
+        rr.curL = (0.0, 0.0)
 
-        data = TAMode.runTAM(tps, rr, (0, 0))
+        data = TAMode.runTAM(tps, rr, (0.0, 0.0))
 
-        @test all(data * TAMode.pYLS .≈ 0)
+        @test aboutZero.(data * TAMode.pYLS)
     end
 end

--- a/test/testLS.jl
+++ b/test/testLS.jl
@@ -59,4 +59,14 @@
         TAMode.TAMreact(dnorm, uLong, tt, 0.0)
         @test norm(dnorm) .< 0.001
     end
+    
+    @testset "LS: Test that if no ligand is present, we don’t see any." begin
+        rr = TAMode.Lsparam(fill(0.2, 9))
+        rr.curL = (0, 0)
+
+        data = TAMode.runTAM(tps, rr, (0, 0))
+
+        @test all(data * TAMode.totalLS .≈ 0)
+        @test all(data * TAMode.surfaceLS .≈ 0)
+    end
 end

--- a/test/testLS.jl
+++ b/test/testLS.jl
@@ -60,13 +60,30 @@
         @test norm(dnorm) .< 0.001
     end
     
-    @testset "LS: Test that if no ligand is present, we don’t see any." begin
+    @testset "LS: Test that if no Gas6 is present, we don’t see any." begin
+        rr = TAMode.Lsparam(fill(0.2, 9))
+        rr.curL = (0, 0)
+
+        data = TAMode.runTAM(tps, rr, (0, 10))
+
+        @test all(data * TAMode.GasLS .≈ 0)
+    end
+    
+    @testset "LS: Test that if no Protein S is present, we don’t see any." begin
+        rr = TAMode.Lsparam(fill(0.2, 9))
+        rr.curL = (0, 0)
+
+        data = TAMode.runTAM(tps, rr, (10, 0))
+
+        @test all(data * TAMode.PROSLS .≈ 0)
+    end
+    
+    @testset "LS: Test that if no ligand is present, we don’t see any pY." begin
         rr = TAMode.Lsparam(fill(0.2, 9))
         rr.curL = (0, 0)
 
         data = TAMode.runTAM(tps, rr, (0, 0))
 
-        @test all(data * TAMode.totalLS .≈ 0)
-        @test all(data * TAMode.surfaceLS .≈ 0)
+        @test all(data * TAMode.pYLS .≈ 0)
     end
 end


### PR DESCRIPTION
Added the total Gas, PROS, and pY vectors & tests for when no ligand is present. The Gas6 and pY tests passed, but the Protein S test failed. I printed out the vector we were testing (data * TAMode.PROSLS) to see which values weren't zero and the last value in the vector was ~ -4.877e-21.