### PR TITLE
Fitting fix

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -14,9 +14,9 @@ version = "0.3.3"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c88cfc7f9c1f9f8633cddf0b56e86302b70f64c5"
+git-tree-sha1 = "fd04049c7dd78cfef0b06cdc1f0f181467655712"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "1.0.1"
+version = "1.1.0"
 
 [[AdvancedHMC]]
 deps = ["ArgCheck", "InplaceOps", "LinearAlgebra", "Parameters", "ProgressMeter", "Random", "Requires", "Statistics", "StatsBase", "StatsFuns"]
@@ -391,6 +391,7 @@ uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 version = "0.1.2"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[LibVPX_jll]]
@@ -578,7 +579,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.4"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PlotThemes]]
@@ -595,9 +596,9 @@ version = "1.0.4"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "cb6f0a51c4b9f396b7b2ea0b405ada543d5de932"
+git-tree-sha1 = "a784969eee5bfba15d151c260d0f1d724e625592"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.3.5"
+version = "1.3.6"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -830,9 +831,9 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[VectorizationBase]]
 deps = ["CpuId", "LinearAlgebra"]
-git-tree-sha1 = "13463c5703d9e75b2eab93f6c94239426af49221"
+git-tree-sha1 = "56423de8e50e538727b2e4f12ba247ef7339d1be"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-version = "0.12.3"
+version = "0.12.4"
 
 [[VertexSafeGraphs]]
 deps = ["LightGraphs"]

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -32,7 +32,7 @@ function dataModelCalc(tps, g6conc, params, scale, scaleSurf)
 end
 
 
-@model AXLfit(pYDataExp, surfDataExp, totDataExp, tps, g6conc, ::Type{TV} = Vector{Float64}) where {TV} = begin
+@model AXLfit(pYDataExp, surfDataExp, totDataExp, sqResid, tps, g6conc, ::Type{TV} = Vector{Float64}) where {TV} = begin
     internalize ~ LogNormal(log(0.1), 0.1)
     pYinternalize ~ LogNormal(log(1.0), 0.1)
     sortF ~ Beta(1.0, 10.0)
@@ -93,4 +93,4 @@ function plot_overlay(chn, tps, g6conc)
     xlabel!("Gas6 Concentration (nM)")
 end
 
-A549model = AXLfit(TAMode.pYA549, TAMode.surfA549, TAMode.totA549, TAMode.tpsA549, TAMode.gasA549)
+A549model = AXLfit(TAMode.pYA549, TAMode.surfA549, TAMode.totA549, [0.0], TAMode.tpsA549, TAMode.gasA549)


### PR DESCRIPTION
Observations versus prior assumptions are determined by whether the variable symbol appears in the argument list. So, I added `sqResid` to the argument list. Even though it's overwritten, it fixes the problem from within the compiler. I checked that this is the case by printing `sqResid` before and after the `~` statement.