### PR TITLE
Fix autocrine handling.

### DIFF
--- a/src/TAMode.jl
+++ b/src/TAMode.jl
@@ -90,7 +90,7 @@ function runTAM(tps::AbstractVector{Float64}, params::Union{Rates{T}, Lsrates{T}
         params.gasCur += ligStim
     else
         @assert params isa Lsrates
-        params.curL += ligStim
+        params.curL .+= ligStim
     end
 
     return runTAMinit(tps, params, solInit)

--- a/src/TAMode.jl
+++ b/src/TAMode.jl
@@ -87,10 +87,10 @@ function runTAM(tps::AbstractVector{Float64}, params::Union{Rates{T}, Lsrates{T}
     solInit = getAutocrine(params)
 
     if params isa Rates
-        params.gasCur = ligStim
+        params.gasCur += ligStim
     else
         @assert params isa Lsrates
-        params.curL = ligStim
+        params.curL += ligStim
     end
 
     return runTAMinit(tps, params, solInit)

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -17,7 +17,7 @@ function dataModelCalc(tps, g6conc, params, scale, scaleSurf)
     totAXL = TAMode.total .* TAMode.recpSpecific[1]
 
     paramsStart = param(params)
-    solInit = getAutocrine(params)
+    solInit = getAutocrine(paramsStart)
 
     Threads.@threads for ii = 1:length(g6conc)
         params = deepcopy(paramsStart)

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -16,11 +16,13 @@ function dataModelCalc(tps, g6conc, params, scale, scaleSurf)
     surfAXL = TAMode.surface .* TAMode.recpSpecific[1]
     totAXL = TAMode.total .* TAMode.recpSpecific[1]
 
-    params = param(params)
+    paramsStart = param(params)
     solInit = getAutocrine(params)
 
     Threads.@threads for ii = 1:length(g6conc)
-        params.gasCur = g6conc[ii]
+        params = deepcopy(paramsStart)
+
+        params.gasCur += g6conc[ii]
         data = runTAMinit(tps, params, solInit)
 
         pYresids[:, ii] = (data * pYAXL) * scale
@@ -35,7 +37,7 @@ end
 @model AXLfit(pYDataExp, surfDataExp, totDataExp, sqResid, tps, g6conc, ::Type{TV} = Vector{Float64}) where {TV} = begin
     internalize ~ LogNormal(log(0.1), 0.1)
     pYinternalize ~ LogNormal(log(1.0), 0.1)
-    sortF ~ Beta(1.0, 10.0)
+    sortF ~ Beta(2.0, 20.0)
     kRec ~ LogNormal(log(0.1), 0.1)
     kDeg ~ LogNormal(log(0.01), 0.1)
     xFwd ~ LogNormal(-3.0, 1.0)


### PR DESCRIPTION
Stimulation should add ligand to the autocrine amount, not overwrite the autocrine amount. This should fix the model fit not matching the data at low concentrations of ligand.